### PR TITLE
chore: 修改 status bar 的文案和取消颜色变化

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,16 +7,14 @@ export async function activate(context: ExtensionContext) {
 
   const statusBar = createBottomBar({
     position: 'right',
-    color: isEnable ? '#bef264' : '#f87171',
-    text: `$(symbol-array) Symbol`,
+    text: `$(${isEnable ? 'symbol-array' : 'circle-slash'}) Symbol`,
     command: 'symbol-mapping-conversion.toggleStatusBar',
   })
 
   statusBar.show()
 
   const updateStatusBar = () => {
-    statusBar.text = `$(symbol-array) Symbol`,
-    statusBar.color = isEnable ? '#bef264' : '#f87171'
+    statusBar.text = `$(${isEnable ? 'symbol-array' : 'circle-slash'}) Symbol`
   }
 
   disposes.push(registerCommand('symbol-mapping-conversion.toggleStatusBar', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,14 +8,14 @@ export async function activate(context: ExtensionContext) {
   const statusBar = createBottomBar({
     position: 'right',
     color: isEnable ? '#bef264' : '#f87171',
-    text: isEnable ? 'symbol-mapping-conversion: ✅' : 'symbol-mapping-conversion: ❌',
+    text: `$(symbol-array) Symbol`,
     command: 'symbol-mapping-conversion.toggleStatusBar',
   })
 
   statusBar.show()
 
   const updateStatusBar = () => {
-    statusBar.text = isEnable ? 'symbol-mapping-conversion: ✅' : 'symbol-mapping-conversion: ❌'
+    statusBar.text = `$(symbol-array) Symbol`,
     statusBar.color = isEnable ? '#bef264' : '#f87171'
   }
 


### PR DESCRIPTION
1. 之前使用 `symbol-mapping-conversion` 作为 status text 感觉有点冗长，因此换成 vscode 内置的 icon。
2. status bar 较少出现颜色，因此取消使用颜色来区别插件的是否启用。
![image](https://github.com/Simon-He95/symbol-mapping-conversion/assets/69381867/890c255f-44a8-49c8-a004-fc10f9e61d63)
![image](https://github.com/Simon-He95/symbol-mapping-conversion/assets/69381867/8fa49361-36ee-4cf6-a03c-62928abaca68)

